### PR TITLE
Add feedback-driven scoring calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,88 @@
 # Attuario-Ai-
-implementare ai
+
+Toolkit per valutazione automatica dei contenuti attuariali del dominio attuario.eu.
+
+## Funzionalità principali
+
+- **Crawler** limitato al dominio per raccogliere pagine HTML pubbliche e rispettoso di `robots.txt`.
+- **Parser** HTML → testo con estrazione di metadata (titolo, date, autore).
+- **Estrazione metriche** attuariali (terminologia, numeri, formule, citazioni normative).
+- **Scoring** composito secondo i pesi del framework attuariale proposto (accuratezza, trasparenza, completezza, aggiornamento, chiarezza) con possibilità di calibrazione dai feedback umani.
+- **Reportistica** in formato CSV e JSON con riepilogo sintetico delle performance del dominio.
+
+## Requisiti
+
+- Python 3.10+
+- Dipendenze elencate in `requirements.txt`
+
+Installazione delle dipendenze:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Esecuzione rapida
+
+```bash
+python scripts/run_pipeline.py https://www.attuario.eu --max-pages 50 --max-depth 2 --delay 0.5 --output-dir outputs
+```
+
+Il comando genera:
+
+- `outputs/report.csv`: riepilogo tabellare pagina per pagina.
+- `outputs/report.json`: versione JSON con metriche dettagliate.
+- `outputs/summary.json`: statistiche aggregate (numero pagine, punteggio medio/min/max).
+
+### Calibrazione dei pesi con feedback umano
+
+1. Prepara un file `labels.json` con le URL revisionate manualmente e il punteggio assegnato (0–100):
+
+   ```json
+   [
+     {"url": "https://www.attuario.eu/articolo-1", "target_score": 85.0},
+     {"url": "https://www.attuario.eu/articolo-2", "target_score": 62.0}
+   ]
+   ```
+
+2. Allena i pesi facendo apprendere alla pipeline le tue valutazioni:
+
+   ```bash
+   python scripts/train_weights.py https://www.attuario.eu labels.json --output pesi_calibrati.json
+   ```
+
+   Il comando esegue un crawl mirato, calcola i componenti (accuratezza, trasparenza, ecc.) e stima i pesi ottimali tramite regressione ai minimi quadrati.
+
+3. Riutilizza i pesi ottenuti per le successive analisi automatiche:
+
+   ```bash
+   python scripts/run_pipeline.py https://www.attuario.eu --weights pesi_calibrati.json --output-dir outputs
+   ```
+
+La stampa a video del training include MAE e MSE per monitorare l'accuratezza dell'apprendimento.
+
+## Struttura del progetto
+
+```
+attuario_ai/
+  crawler.py      # crawler BFS sul dominio
+  parser.py       # parser HTML → testo + metadata
+  extraction.py   # metriche euristiche dei contenuti
+  scoring.py      # calcolo punteggi e classificazione
+  learning.py     # apprendimento dei pesi da feedback manuali
+  pipeline.py     # orchestrazione e generazione report
+scripts/
+  run_pipeline.py # CLI per eseguire la pipeline completa
+  train_weights.py # CLI per calibrare i pesi
+```
+
+## Limitazioni note
+
+- Lo scoring è euristico: necessita calibrazione con revisione umana.
+- Il rispetto di `robots.txt` dipende dalle direttive pubblicate dal sito (crawl-delay e permessi).
+- La verifica numerica è basata su presenze di valori e formule, non sulla correttezza dei calcoli.
+
+## Prossimi passi suggeriti
+
+- Integrare unit test numerici sui valori estratti dal testo.
+- Aggiungere un modello NLP per classificare tipologia degli articoli.
+- Collegare pipeline a scheduler (cron/CI) per aggiornamenti periodici.

--- a/attuario_ai/__init__.py
+++ b/attuario_ai/__init__.py
@@ -1,0 +1,25 @@
+"""Attuario AI content quality assessment toolkit."""
+
+from .crawler import Crawler, CrawlResult
+from .parser import PageParser, ParsedPage
+from .extraction import extract_metrics
+from .scoring import ScoreWeights, score_page, PageScore, compute_components, apply_weights
+from .pipeline import EvaluationPipeline
+from .learning import TrainingSample, WeightLearner, samples_from_results
+
+__all__ = [
+    "Crawler",
+    "CrawlResult",
+    "PageParser",
+    "ParsedPage",
+    "extract_metrics",
+    "ScoreWeights",
+    "score_page",
+    "PageScore",
+    "compute_components",
+    "apply_weights",
+    "EvaluationPipeline",
+    "TrainingSample",
+    "WeightLearner",
+    "samples_from_results",
+]

--- a/attuario_ai/crawler.py
+++ b/attuario_ai/crawler.py
@@ -1,0 +1,187 @@
+"""Simple crawler constrained to a single domain."""
+
+from __future__ import annotations
+
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Deque, Iterable, Optional, Set
+from urllib.parse import urljoin, urlparse
+from urllib import robotparser
+
+import requests
+from requests import Response
+
+
+@dataclass
+class CrawlResult:
+    """Represents a crawled page."""
+
+    url: str
+    status_code: int
+    html: str
+    fetched_at: float
+    referer: Optional[str] = None
+    error: Optional[str] = None
+
+
+class RobotsPolicy:
+    """Utility wrapper around ``robots.txt`` directives for the target domain."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        session: requests.Session,
+        timeout: float,
+        user_agent: str,
+    ) -> None:
+        self.user_agent = user_agent
+        self._parser = robotparser.RobotFileParser()
+        self._available = False
+        self.crawl_delay: Optional[float] = None
+        self.sitemaps: tuple[str, ...] = ()
+
+        robots_url = urljoin(base_url.rstrip("/"), "/robots.txt")
+        try:
+            response = session.get(robots_url, timeout=timeout)
+            if response.status_code < 400 and response.text.strip():
+                self._parser.parse(response.text.splitlines())
+                self._available = True
+                self.crawl_delay = (
+                    self._parser.crawl_delay(user_agent)
+                    or self._parser.crawl_delay("*")
+                )
+                sitemaps = self._parser.site_maps() or []
+                self.sitemaps = tuple(sitemaps)
+        except requests.RequestException:
+            self._available = False
+
+    def allows(self, url: str) -> bool:
+        if not self._available:
+            return True
+        return self._parser.can_fetch(self.user_agent, url)
+
+
+class Crawler:
+    """Breadth-first crawler restricted to a target domain that respects ``robots.txt``."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        max_pages: int = 100,
+        max_depth: int = 2,
+        delay_seconds: float = 0.5,
+        session: Optional[requests.Session] = None,
+        timeout: float = 10.0,
+        user_agent: str = "AttuarioAI/0.1 (+https://github.com)",
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.max_pages = max_pages
+        self.max_depth = max_depth
+        self.delay_seconds = delay_seconds
+        self.timeout = timeout
+        self._session = session or requests.Session()
+        self._session.headers.setdefault("User-Agent", user_agent)
+
+        parsed = urlparse(self.base_url)
+        if not parsed.scheme or not parsed.netloc:
+            raise ValueError(f"Invalid base_url: {base_url}")
+        self._netloc = parsed.netloc
+
+        self._robots = RobotsPolicy(
+            self.base_url,
+            session=self._session,
+            timeout=self.timeout,
+            user_agent=self._session.headers["User-Agent"],
+        )
+        if self._robots.crawl_delay:
+            self.delay_seconds = max(self.delay_seconds, self._robots.crawl_delay)
+
+    def close(self) -> None:
+        self._session.close()
+
+    def crawl(self, seeds: Optional[Iterable[str]] = None) -> Iterable[CrawlResult]:
+        queue: Deque[tuple[str, int, Optional[str]]] = deque()
+        visited: Set[str] = set()
+
+        if seeds is None:
+            queue.append((self.base_url, 0, None))
+        else:
+            for seed in seeds:
+                queue.append((seed, 0, None))
+
+        pages_crawled = 0
+
+        while queue and pages_crawled < self.max_pages:
+            url, depth, referer = queue.popleft()
+            normalized = self._normalize_url(url)
+            if normalized in visited:
+                continue
+            if not self._robots.allows(normalized):
+                continue
+            visited.add(normalized)
+
+            result = self._fetch(normalized, referer)
+            yield result
+            pages_crawled += 1
+
+            if result.error or depth >= self.max_depth:
+                continue
+
+            for link in self._extract_links(result.html, normalized):
+                if link not in visited and self._robots.allows(link):
+                    queue.append((link, depth + 1, normalized))
+
+            if queue and self.delay_seconds > 0:
+                time.sleep(self.delay_seconds)
+
+    def _fetch(self, url: str, referer: Optional[str]) -> CrawlResult:
+        try:
+            response: Response = self._session.get(url, timeout=self.timeout)
+            response.raise_for_status()
+            html = response.text
+            status_code = response.status_code
+            error = None
+        except requests.RequestException as exc:
+            html = ""
+            status_code = getattr(exc.response, "status_code", 0) if hasattr(exc, "response") else 0
+            error = str(exc)
+        return CrawlResult(
+            url=url,
+            status_code=status_code,
+            html=html,
+            fetched_at=time.time(),
+            referer=referer,
+            error=error,
+        )
+
+    def _extract_links(self, html: str, current_url: str) -> Set[str]:
+        from bs4 import BeautifulSoup  # lazy import to keep dependency optional for non-crawl use
+
+        soup = BeautifulSoup(html, "html.parser")
+        links: Set[str] = set()
+        for tag in soup.find_all("a", href=True):
+            href = tag["href"].strip()
+            if href.startswith("#"):
+                continue
+            joined = urljoin(current_url, href)
+            parsed = urlparse(joined)
+            if parsed.netloc == self._netloc and parsed.scheme in {"http", "https"}:
+                clean = self._normalize_url(joined)
+                links.add(clean)
+        return links
+
+    def _normalize_url(self, url: str) -> str:
+        parsed = urlparse(url)
+        normalized = parsed._replace(fragment="").geturl()
+        if normalized.endswith("/") and normalized != self.base_url:
+            normalized = normalized[:-1]
+        return normalized
+
+    def __enter__(self) -> "Crawler":
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.close()

--- a/attuario_ai/extraction.py
+++ b/attuario_ai/extraction.py
@@ -1,0 +1,83 @@
+"""Feature extraction helpers for actuarial content analysis."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass
+from typing import Dict, List
+
+ACTUARIAL_TERMS = {
+    "solvency", "solvency ii", "ivass", "eiopa", "riserva", "best estimate",
+    "premio", "longevità", "mortalità", "stress test", "discount rate",
+    "best estimate", "risk margin", "scr", "bscr", "premio puro", "var",
+    "value at risk", "tasso tecnico", "attuario", "riserva matematica",
+}
+
+FORMULA_PATTERNS = [
+    re.compile(r"\\begin\{equation\}"),
+    re.compile(r"\\\[(.*?)\\\]", re.DOTALL),
+    re.compile(r"[=\u2260\u2264\u2265]"),
+]
+
+CITATION_PATTERNS = [
+    re.compile(r"\b(?:ivass|eiopa|isvap|solvency\s*ii|european insurance)\b", re.IGNORECASE),
+    re.compile(r"\bregolament[oi]|circolare|normativa\b", re.IGNORECASE),
+]
+
+
+@dataclass
+class PageMetrics:
+    """Aggregated metrics extracted from a parsed page."""
+
+    word_count: int
+    actuarial_terms: Dict[str, int]
+    numeric_tokens: int
+    has_formula: bool
+    has_table: bool
+    has_list: bool
+    citation_matches: int
+    example_values: List[float]
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "word_count": self.word_count,
+            "actuarial_terms": self.actuarial_terms,
+            "numeric_tokens": self.numeric_tokens,
+            "has_formula": self.has_formula,
+            "has_table": self.has_table,
+            "has_list": self.has_list,
+            "citation_matches": self.citation_matches,
+            "example_values": self.example_values,
+        }
+
+
+def extract_metrics(parsed_text: str, html: str) -> PageMetrics:
+    lower_text = parsed_text.lower()
+    words = re.findall(r"\b\w+\b", lower_text)
+    word_count = len(words)
+
+    actuarial_counter: Counter[str] = Counter()
+    for term in ACTUARIAL_TERMS:
+        if term in lower_text:
+            actuarial_counter[term] = lower_text.count(term)
+
+    numeric_tokens = len(re.findall(r"\b\d+(?:[.,]\d+)?\b", parsed_text))
+    example_values = [float(token.replace(",", ".")) for token in re.findall(r"\b\d+(?:[.,]\d+)?\b", parsed_text)[:20]]
+
+    has_formula = any(pattern.search(parsed_text) for pattern in FORMULA_PATTERNS)
+    has_table = "<table" in html.lower()
+    has_list = "<ul" in html.lower() or "<ol" in html.lower()
+
+    citation_matches = sum(pattern.findall(parsed_text).__len__() for pattern in CITATION_PATTERNS)
+
+    return PageMetrics(
+        word_count=word_count,
+        actuarial_terms=dict(actuarial_counter),
+        numeric_tokens=numeric_tokens,
+        has_formula=has_formula,
+        has_table=has_table,
+        has_list=has_list,
+        citation_matches=citation_matches,
+        example_values=example_values,
+    )

--- a/attuario_ai/learning.py
+++ b/attuario_ai/learning.py
@@ -1,0 +1,96 @@
+"""Utilities to learn scoring weights from human feedback."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, Sequence
+
+import numpy as np
+
+from .scoring import ScoreWeights, apply_weights, compute_components
+
+
+COMPONENT_KEYS = ("accuracy", "transparency", "completeness", "freshness", "clarity")
+
+
+@dataclass
+class TrainingSample:
+    """Represents a manually reviewed page used to calibrate weights."""
+
+    url: str
+    components: Dict[str, float]
+    target_score: float
+
+
+class WeightLearner:
+    """Fit ``ScoreWeights`` using least squares on feedback samples."""
+
+    def __init__(self, *, min_samples: int = 2) -> None:
+        self.min_samples = min_samples
+
+    def fit(self, samples: Sequence[TrainingSample]) -> ScoreWeights:
+        if len(samples) < self.min_samples:
+            raise ValueError(f"At least {self.min_samples} samples are required to fit weights")
+
+        matrix = np.array([[sample.components.get(key, 0.0) for key in COMPONENT_KEYS] for sample in samples], dtype=float)
+        targets = np.array([sample.target_score for sample in samples], dtype=float)
+
+        solution, *_ = np.linalg.lstsq(matrix, targets, rcond=None)
+        solution = np.clip(solution, 0.0, None)
+
+        if not solution.any():
+            return ScoreWeights()
+
+        total = solution.sum()
+        if total <= 0:
+            return ScoreWeights()
+
+        normalized = solution / total
+        return ScoreWeights(
+            accuracy=float(normalized[0]),
+            transparency=float(normalized[1]),
+            completeness=float(normalized[2]),
+            freshness=float(normalized[3]),
+            clarity=float(normalized[4]),
+        )
+
+    def evaluate(self, samples: Sequence[TrainingSample], weights: ScoreWeights) -> Dict[str, float]:
+        predictions = [apply_weights(sample.components, weights) for sample in samples]
+        errors = [prediction - sample.target_score for prediction, sample in zip(predictions, samples)]
+        absolute_errors = [abs(error) for error in errors]
+        if not errors:
+            return {"count": 0, "mae": 0.0, "mse": 0.0}
+        mae = sum(absolute_errors) / len(absolute_errors)
+        mse = sum(error ** 2 for error in errors) / len(errors)
+        return {"count": len(errors), "mae": round(mae, 2), "mse": round(mse, 2)}
+
+
+def samples_from_results(
+    results: Iterable["EvaluationResult"],
+    targets: Mapping[str, float],
+) -> List[TrainingSample]:
+    from .pipeline import EvaluationResult  # Local import to avoid circular dependency
+
+    lookup = {normalize_url(url): score for url, score in targets.items()}
+    samples: List[TrainingSample] = []
+    for result in results:
+        if not isinstance(result, EvaluationResult):
+            continue
+        normalized_url = normalize_url(result.page.url)
+        if normalized_url not in lookup:
+            continue
+        metadata = dict(result.page.metadata)
+        metadata["url"] = result.page.url
+        components = {key: float(value) for key, value in compute_components(result.metrics, metadata).items()}
+        samples.append(
+            TrainingSample(
+                url=result.page.url,
+                components=components,
+                target_score=float(lookup[normalized_url]),
+            )
+        )
+    return samples
+
+
+def normalize_url(url: str) -> str:
+    return url.rstrip("/")

--- a/attuario_ai/parser.py
+++ b/attuario_ai/parser.py
@@ -1,0 +1,80 @@
+"""HTML parsing and content normalization utilities."""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from bs4 import BeautifulSoup
+
+
+@dataclass
+class ParsedPage:
+    """Structured representation of an HTML page."""
+
+    url: str
+    title: str
+    text: str
+    html: str
+    fetched_at: dt.datetime
+    metadata: Dict[str, Optional[str]]
+
+
+class PageParser:
+    """Parses raw HTML into structured text and metadata."""
+
+    def __init__(self, *, language: str = "it") -> None:
+        self.language = language
+
+    def parse(self, url: str, html: str, fetched_at: float) -> ParsedPage:
+        soup = BeautifulSoup(html, "html.parser")
+        title_tag = soup.find("title")
+        title = title_tag.get_text(strip=True) if title_tag else ""
+
+        main = self._select_main_content(soup)
+        text = main.get_text("\n", strip=True)
+
+        metadata = {
+            "language": self.language,
+            "title": title,
+            "description": self._meta_content(soup, "description"),
+            "published": self._find_datetime(soup, "article:published_time"),
+            "modified": self._find_datetime(soup, "article:modified_time"),
+            "author": self._meta_content(soup, "author"),
+        }
+
+        return ParsedPage(
+            url=url,
+            title=title,
+            text=text,
+            html=html,
+            fetched_at=dt.datetime.fromtimestamp(fetched_at, tz=dt.timezone.utc),
+            metadata=metadata,
+        )
+
+    def _select_main_content(self, soup: BeautifulSoup) -> BeautifulSoup:
+        candidates = []
+        for selector in ("article", "main", "div", "body"):
+            node = soup.find(selector)
+            if node:
+                candidates.append((len(node.get_text()), node))
+        if not candidates:
+            return soup
+        _, best = max(candidates, key=lambda pair: pair[0])
+        return best
+
+    def _meta_content(self, soup: BeautifulSoup, name: str) -> Optional[str]:
+        tag = soup.find("meta", attrs={"name": name})
+        if tag and tag.get("content"):
+            return tag["content"].strip()
+        return None
+
+    def _find_datetime(self, soup: BeautifulSoup, property_name: str) -> Optional[str]:
+        tag = soup.find("meta", attrs={"property": property_name})
+        if tag and tag.get("content"):
+            return tag["content"].strip()
+        time_tag = soup.find("time")
+        if time_tag and time_tag.get("datetime"):
+            return time_tag["datetime"].strip()
+        return None

--- a/attuario_ai/pipeline.py
+++ b/attuario_ai/pipeline.py
@@ -1,0 +1,141 @@
+"""High level orchestration for the evaluation workflow."""
+
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from .crawler import Crawler
+from .extraction import PageMetrics, extract_metrics
+from .parser import PageParser, ParsedPage
+from .scoring import PageScore, ScoreWeights, score_page
+
+
+@dataclass
+class EvaluationResult:
+    page: ParsedPage
+    metrics: PageMetrics
+    score: PageScore
+
+
+class EvaluationPipeline:
+    """End-to-end pipeline that crawls, parses and scores pages."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        max_pages: int = 25,
+        max_depth: int = 1,
+        delay_seconds: float = 0.2,
+        weights: Optional[ScoreWeights] = None,
+    ) -> None:
+        self.base_url = base_url
+        self.crawler = Crawler(base_url, max_pages=max_pages, max_depth=max_depth, delay_seconds=delay_seconds)
+        self.parser = PageParser()
+        self.weights = weights or ScoreWeights()
+
+    def run(self, seeds: Optional[Iterable[str]] = None) -> List[EvaluationResult]:
+        results: List[EvaluationResult] = []
+        for crawled in self.crawler.crawl(seeds=seeds):
+            if crawled.error or not crawled.html:
+                continue
+            parsed = self.parser.parse(crawled.url, crawled.html, crawled.fetched_at)
+            metrics = extract_metrics(parsed.text, parsed.html)
+            metadata = {**parsed.metadata, "url": parsed.url}
+            score = score_page(metrics, metadata, self.weights)
+            results.append(EvaluationResult(page=parsed, metrics=metrics, score=score))
+        return results
+
+    def export_csv(self, results: Iterable[EvaluationResult], path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(
+                handle,
+                fieldnames=[
+                    "url",
+                    "title",
+                    "score",
+                    "classification",
+                    "accuracy",
+                    "transparency",
+                    "completeness",
+                    "freshness",
+                    "clarity",
+                    "word_count",
+                    "numeric_tokens",
+                    "has_formula",
+                    "has_table",
+                    "has_list",
+                    "citation_matches",
+                    "actuarial_terms",
+                ],
+            )
+            writer.writeheader()
+            for result in results:
+                row = {
+                    "url": result.page.url,
+                    "title": result.page.title,
+                    "score": result.score.composite,
+                    "classification": result.score.classification,
+                    "accuracy": result.score.components["accuracy"],
+                    "transparency": result.score.components["transparency"],
+                    "completeness": result.score.components["completeness"],
+                    "freshness": result.score.components["freshness"],
+                    "clarity": result.score.components["clarity"],
+                    "word_count": result.metrics.word_count,
+                    "numeric_tokens": result.metrics.numeric_tokens,
+                    "has_formula": result.metrics.has_formula,
+                    "has_table": result.metrics.has_table,
+                    "has_list": result.metrics.has_list,
+                    "citation_matches": result.metrics.citation_matches,
+                    "actuarial_terms": "; ".join(
+                        f"{term}:{count}" for term, count in sorted(result.metrics.actuarial_terms.items())
+                    ),
+                }
+                writer.writerow(row)
+
+    def export_json(self, results: Iterable[EvaluationResult], path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        serializable = [
+            {
+                "page": {
+                    "url": result.page.url,
+                    "title": result.page.title,
+                    "metadata": result.page.metadata,
+                    "fetched_at": result.page.fetched_at.isoformat(),
+                },
+                "metrics": result.metrics.to_dict(),
+                "score": asdict(result.score),
+            }
+            for result in results
+        ]
+        path.write_text(json.dumps(serializable, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    def summary(self, results: Iterable[EvaluationResult]) -> dict:
+        scores = [result.score.composite for result in results]
+        if not scores:
+            return {
+                "count": 0,
+                "average": 0.0,
+                "minimum": 0.0,
+                "maximum": 0.0,
+            }
+        return {
+            "count": len(scores),
+            "average": round(sum(scores) / len(scores), 2),
+            "minimum": round(min(scores), 2),
+            "maximum": round(max(scores), 2),
+        }
+
+    def close(self) -> None:
+        self.crawler.close()
+
+    def __enter__(self) -> "EvaluationPipeline":
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.close()

--- a/attuario_ai/scoring.py
+++ b/attuario_ai/scoring.py
@@ -1,0 +1,154 @@
+"""Heuristic scoring for actuarial content quality."""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from typing import Dict, Mapping
+
+from .extraction import PageMetrics
+
+
+@dataclass
+class ScoreWeights:
+    accuracy: float = 0.4
+    transparency: float = 0.2
+    completeness: float = 0.2
+    freshness: float = 0.1
+    clarity: float = 0.1
+
+    def normalize(self) -> "ScoreWeights":
+        total = self.accuracy + self.transparency + self.completeness + self.freshness + self.clarity
+        if not total:
+            raise ValueError("Weights sum to zero")
+        return ScoreWeights(
+            accuracy=self.accuracy / total,
+            transparency=self.transparency / total,
+            completeness=self.completeness / total,
+            freshness=self.freshness / total,
+            clarity=self.clarity / total,
+        )
+
+    def to_dict(self) -> Dict[str, float]:
+        return {
+            "accuracy": self.accuracy,
+            "transparency": self.transparency,
+            "completeness": self.completeness,
+            "freshness": self.freshness,
+            "clarity": self.clarity,
+        }
+
+    @classmethod
+    def from_dict(cls, values: Mapping[str, float]) -> "ScoreWeights":
+        return cls(
+            accuracy=float(values.get("accuracy", cls.accuracy)),
+            transparency=float(values.get("transparency", cls.transparency)),
+            completeness=float(values.get("completeness", cls.completeness)),
+            freshness=float(values.get("freshness", cls.freshness)),
+            clarity=float(values.get("clarity", cls.clarity)),
+        )
+
+
+@dataclass
+class PageScore:
+    url: str
+    composite: float
+    components: Dict[str, float]
+    classification: str
+
+
+FRESHNESS_DECAY_DAYS = 365
+
+
+def score_page(metrics: PageMetrics, metadata: Dict[str, str], weights: ScoreWeights) -> PageScore:
+    components = compute_components(metrics, metadata)
+    composite = apply_weights(components, weights)
+    classification = _classify(composite)
+    return PageScore(
+        url=metadata.get("url", ""),
+        composite=round(composite, 2),
+        components={key: round(value, 2) for key, value in components.items()},
+        classification=classification,
+    )
+
+
+def compute_components(metrics: PageMetrics, metadata: Dict[str, str]) -> Dict[str, float]:
+    return {
+        "accuracy": _score_accuracy(metrics),
+        "transparency": _score_transparency(metrics),
+        "completeness": _score_completeness(metrics),
+        "freshness": _score_freshness(metadata.get("modified") or metadata.get("published")),
+        "clarity": _score_clarity(metrics),
+    }
+
+
+def apply_weights(components: Dict[str, float], weights: ScoreWeights) -> float:
+    normalized = weights.normalize()
+    return (
+        components.get("accuracy", 0.0) * normalized.accuracy
+        + components.get("transparency", 0.0) * normalized.transparency
+        + components.get("completeness", 0.0) * normalized.completeness
+        + components.get("freshness", 0.0) * normalized.freshness
+        + components.get("clarity", 0.0) * normalized.clarity
+    )
+
+
+def _score_accuracy(metrics: PageMetrics) -> float:
+    if metrics.numeric_tokens == 0:
+        return 40.0
+    ratio = min(metrics.numeric_tokens / max(metrics.word_count, 1), 0.2)
+    base = 60.0 + ratio * 200
+    if metrics.has_formula:
+        base += 10
+    return min(base, 100.0)
+
+
+def _score_transparency(metrics: PageMetrics) -> float:
+    if metrics.citation_matches == 0:
+        return 30.0
+    return min(30 + metrics.citation_matches * 15, 100.0)
+
+
+def _score_completeness(metrics: PageMetrics) -> float:
+    bonus = 0
+    if metrics.has_table:
+        bonus += 20
+    if metrics.has_list:
+        bonus += 10
+    if metrics.actuarial_terms:
+        bonus += min(len(metrics.actuarial_terms) * 5, 30)
+    return min(40 + bonus, 100.0)
+
+
+def _score_freshness(timestamp: str | None) -> float:
+    if not timestamp:
+        return 50.0
+    try:
+        parsed = dt.datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        return 60.0
+    now = dt.datetime.now(dt.timezone.utc)
+    delta = now - parsed
+    if delta.days < 0:
+        return 80.0
+    decay = min(delta.days / FRESHNESS_DECAY_DAYS, 1.0)
+    return max(20.0, 100.0 * (1 - decay))
+
+
+def _score_clarity(metrics: PageMetrics) -> float:
+    if metrics.word_count == 0:
+        return 40.0
+    avg_numbers = metrics.numeric_tokens / metrics.word_count
+    if avg_numbers > 0.15:
+        return 65.0
+    return 80.0
+
+
+def _classify(score: float) -> str:
+    if score >= 85:
+        return "Eccellente"
+    if score >= 70:
+        return "Buono"
+    if score >= 50:
+        return "Discreto"
+    return "Criticità"

--- a/evaluation_plan.md
+++ b/evaluation_plan.md
@@ -1,0 +1,100 @@
+# Piano di valutazione attuariale per attuario.eu
+
+Questo documento descrive il framework di audit attuariale basato su crawl pubblico, insieme all'implementazione operativa disponibile nella cartella `attuario_ai`.
+
+## IDEA BURST — 10 idee per integrazione AI nel dominio attuario.eu
+
+1. Pipeline di QA automatica dei contenuti con modello LLM + checker numerico per verifiche matematiche.
+2. Classificatore degli articoli per argomento attuariale (longevità, tariffe, riserve, Solvency II).
+3. Estrattore strutturato di formule e parametri (LaTeX riconosciuto, convertito in JSON).
+4. Sistema di segnatura di rischio/affidabilità per ogni articolo (score probabilistico).
+5. Motore di ricerca semantico con retrieval-powered generation per risposte attuariali contestuali.
+6. Dashboard KPI attuariali (tassi, ipotesi, date di aggiornamento, riferimenti bibliografici).
+7. Alert automatici per contenuti obsoleti o conflitti con normative recenti.
+8. Generatore di sintesi executive e versione “verificata” con calcoli eseguiti e fonti.
+9. Modulo di test dei calcoli (unit tests numerici) che esegue esempi presenti negli articoli.
+10. Sistema di crowdsourced peer review con firma digitale e integrazione dei revisori (anonimizzato).
+
+## TOP PICKS — 3 idee selezionate con giustificazione
+
+1. **Pipeline di QA automatica**: massimizza affidabilità, riduce rischio di errori numerici; priorità alta per dominio attuariale.
+2. **Estrattore di formule/parametri**: abilita riuso, simulazioni e test automatici; elevato ROI tecnico.
+3. **Sistema di segnatura di rischio/affidabilità**: fornisce punteggio leggibile agli utenti e supporta governance dei contenuti.
+
+## PROTOTIPO TECNICO — architettura proposta (per MVP)
+
+- **Crawl & ingest**: crawler Scrapy o requests/BeautifulSoup per scaricare pagine pubbliche.
+- **Preprocessing**: parser HTML → testo, normalizzazione metadata (titolo, date, autore).
+- **NLP & Extraction**: riconoscimento di entità attuariali, parsing di formule, raccolta di valori numerici.
+- **Scoring & QA**: calcolo punteggi sulle dimensioni accuratezza, trasparenza, completezza, aggiornamento, chiarezza.
+- **Storage & Index**: report CSV/JSON + eventuale indice full-text.
+- **Dashboard**: interfaccia per revisori con elenco articoli, score, difetti identificati.
+
+> **Implementazione**: il repository include ora la pipeline `EvaluationPipeline` (vedi `attuario_ai/pipeline.py`) che realizza il flusso end-to-end con crawler, parser, estrazione metrica e scoring.
+
+## LIVELLO DI AUTOMAZIONE (mappa delle attività)
+
+- **Full automation**: crawling, extraction struttura, calcolo punteggi heuristici, esportazione report.
+- **Semi-automation**: revisione qualitativa su pagine con punteggio basso, verifica manuale delle segnalazioni.
+- **Manuale**: approvazione finale da attuario esperto per contenuti critici.
+
+## VALUTAZIONE QUALITÀ — metodologia e scoring esemplificativo
+
+- **Accuratezza numerica (0–100)**: presenza di numeri, formule, densità informativa.
+- **Trasparenza (0–100)**: citazioni normative e riferimenti istituzionali.
+- **Completezza (0–100)**: presenza di tabelle, liste, terminologia attuariale chiave.
+- **Aggiornamento (0–100)**: data di pubblicazione/modifica (ISO 8601) con decadimento annuale.
+- **Chiarezza (0–100)**: equilibrio tra testo e numeri (evita overload numerico).
+
+Il punteggio composito è dato da: `0.4*accuratezza + 0.2*trasparenza + 0.2*completezza + 0.1*aggiornamento + 0.1*chiarezza`.
+
+> **Calibrazione dinamica**: il modulo `attuario_ai/learning.py` e lo script `scripts/train_weights.py` permettono di apprendere pesi aggiornati partendo da revisioni manuali (`labels.json`). Il fitting avviene con regressione ai minimi quadrati e il report restituisce MAE/MSE per monitorare la bontà dell'apprendimento.
+
+Classificazione finale:
+
+- ≥85: **Eccellente**
+- 70–84: **Buono**
+- 50–69: **Discreto**
+- <50: **Criticità**
+
+## ESTRAZIONE METRICHE — lista automatizzabile
+
+- Conteggio parole e valori numerici.
+- Rilevamento terminologia attuariale (Solvency II, IVASS, riserva, ecc.).
+- Presenza di formule (LaTeX o simboli matematici), tabelle HTML, liste strutturate.
+- Citazioni normative (regex dedicate).
+- Valori numerici campione per ripetibilità di test.
+
+Nel codice, queste metriche sono prodotte da `extract_metrics` (`attuario_ai/extraction.py`).
+
+## AUTOMAZIONE AGGIORNAMENTI — workflow consigliato
+
+1. Scheduler (cron/GitHub Actions) lancia `scripts/run_pipeline.py` con cadenza settimanale.
+2. Output CSV/JSON archiviati con timestamp per audit trail.
+3. Delta score > soglia genera alert (email/Slack) verso team contenuti.
+4. Log versionati con Git/DB per assicurare tracciabilità.
+5. Ogni ciclo di revisione manuale alimenta `scripts/train_weights.py` per aggiornare i pesi e chiudere il loop di apprendimento.
+
+## NEXT-STEP — estensioni future
+
+- Integrare parsing avanzato delle sitemap (il crawler ora rispetta già `robots.txt`).
+- Aggiungere modello NLP (spaCy/transformer) per classificazioni più accurate.
+- Implementare test numerici property-based sui valori estratti.
+- Collegare pipeline a dashboard BI (Metabase/Superset) per monitoraggio continuo.
+
+## ESERCIZIO DI CREATIVITÀ (SCAMPER)
+
+Applicazione SCAMPER per migliorare un articolo tecnico:
+
+1. **Substitute**: sostituire esempi statici con notebook interattivo condiviso.
+2. **Combine**: unire normativa e caso pratico in percorso unico.
+3. **Adapt**: adattare modelli standard a dati italiani.
+4. **Modify**: aggiungere checklist di controllo a fine articolo.
+5. **Put to another use**: trasformare contenuti in casi di test automatizzati.
+6. **Eliminate**: rimuovere calcoli ridondanti non verificabili.
+7. **Reverse**: mostrare prima gli errori comuni, poi la soluzione corretta.
+
+## Suggerimenti di studio
+
+- Glossario: mortalità, tasso tecnico, riserva matematica, best estimate, risk margin.
+- Routine consigliata: 1h al giorno per 30 giorni tra letture normative, riproduzione calcoli e revisione report pipeline.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+beautifulsoup4>=4.12
+requests>=2.31
+numpy>=1.26

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Command line entry point for the Attuario AI evaluation pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from attuario_ai import EvaluationPipeline, ScoreWeights
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Evaluate actuarial content quality for a domain.")
+    parser.add_argument("base_url", help="Starting URL for the crawl (e.g. https://www.example.com)")
+    parser.add_argument("--max-pages", type=int, default=25, help="Maximum number of pages to crawl")
+    parser.add_argument("--max-depth", type=int, default=1, help="Maximum crawl depth")
+    parser.add_argument("--delay", type=float, default=0.2, help="Delay between requests in seconds")
+    parser.add_argument("--output-dir", type=Path, default=Path("outputs"), help="Directory for generated reports")
+    parser.add_argument(
+        "--weights",
+        type=Path,
+        help="Optional JSON file containing custom score weights",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    output_dir: Path = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    weights = None
+    if args.weights:
+        weights_data = json.loads(args.weights.read_text(encoding="utf-8"))
+        weights = ScoreWeights.from_dict(weights_data)
+
+    with EvaluationPipeline(
+        args.base_url,
+        max_pages=args.max_pages,
+        max_depth=args.max_depth,
+        delay_seconds=args.delay,
+        weights=weights,
+    ) as pipeline:
+        results = pipeline.run()
+        pipeline.export_csv(results, output_dir / "report.csv")
+        pipeline.export_json(results, output_dir / "report.json")
+        summary = pipeline.summary(results)
+
+    summary_path = output_dir / "summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(json.dumps(summary, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_weights.py
+++ b/scripts/train_weights.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""CLI per apprendere i pesi di scoring a partire da revisioni manuali."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from attuario_ai import EvaluationPipeline
+from attuario_ai.learning import WeightLearner, normalize_url, samples_from_results
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Learn score weights from labelled pages.")
+    parser.add_argument("base_url", help="Base domain for crawling (e.g. https://www.attuario.eu)")
+    parser.add_argument("labels", type=Path, help="JSON file with [{'url': str, 'target_score': float}]")
+    parser.add_argument(
+        "--max-pages",
+        type=int,
+        help="Override max pages for evaluation (defaults to number of labels)",
+    )
+    parser.add_argument(
+        "--delay",
+        type=float,
+        default=0.2,
+        help="Delay between requests while collecting training data",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("weights.json"),
+        help="Destination file for the learned weights",
+    )
+    return parser.parse_args()
+
+
+def load_targets(path: Path) -> Tuple[Dict[str, float], List[str]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise ValueError("Labels file must contain a list of entries")
+    targets: Dict[str, float] = {}
+    seeds: List[str] = []
+    for entry in payload:
+        if not isinstance(entry, dict):
+            continue
+        url = entry.get("url")
+        score = entry.get("target_score")
+        if not url or score is None:
+            continue
+        normalized = normalize_url(str(url))
+        targets[normalized] = float(score)
+        seeds.append(str(url))
+    if not targets:
+        raise ValueError("No valid labelled entries were found")
+    return targets, seeds
+
+
+def main() -> None:
+    args = parse_args()
+    targets, seeds = load_targets(args.labels)
+    max_pages = args.max_pages or len(targets)
+
+    with EvaluationPipeline(
+        args.base_url,
+        max_pages=max_pages,
+        max_depth=0,
+        delay_seconds=args.delay,
+    ) as pipeline:
+        results = pipeline.run(seeds=seeds)
+
+    samples = samples_from_results(results, targets)
+    if not samples:
+        raise ValueError("Unable to match any crawled pages with provided labels")
+
+    learner = WeightLearner()
+    weights = learner.fit(samples)
+    evaluation = learner.evaluate(samples, weights)
+
+    args.output.write_text(json.dumps(weights.to_dict(), indent=2, ensure_ascii=False), encoding="utf-8")
+
+    report = {
+        "weights": weights.to_dict(),
+        "evaluation": evaluation,
+    }
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a learning module and CLI to fit scoring weights from manually labelled pages
- allow the evaluation pipeline to accept custom weights and document the calibration workflow
- update the actuarial evaluation plan to close the feedback loop with periodic retraining

## Testing
- python -m compileall attuario_ai scripts

------
https://chatgpt.com/codex/tasks/task_e_68dc56a48e0c832db71143e5d15281ad